### PR TITLE
Correct loading order to overwirte default one

### DIFF
--- a/lib/denv/rails.rb
+++ b/lib/denv/rails.rb
@@ -13,7 +13,7 @@ end
 
 module Denv
   class Railtie < ::Rails::Railtie
-    DEFAULT_ENV_FILES = %w[.env.local .env.#{Rails.env} .env]
+    DEFAULT_ENV_FILES = %w[.env .env.#{Rails.env} .env.local]
 
     config.before_configuration { load_env }
 

--- a/rails_integration_test.rb
+++ b/rails_integration_test.rb
@@ -13,12 +13,22 @@ Dir.chdir('tmp') do
     new = lines.first(1) + [%!gem "denv", path: "#{path}"!] + lines.drop(1)
     File.open('Gemfile', 'w') {|f| f.puts(new.join("\n")) }
     system('bundle install -j8')
+
     File.open('.env', 'w') {|f| f.puts("XXX=123\nYYY=1\n") }
     result = system(%!bundle exec rails runner 'ENV["XXX"] == "123" ? exit : exit(1)'!)
     if result
-      puts "[#{name}] Succeeded"
+      puts "[#{name}] Test case 'default' succeeded"
     else
-      $stderr.puts "[#{name}] Failed"
+      $stderr.puts "[#{name}] Test case 'default' failed"
+      exit(1)
+    end
+
+    File.open('.env.local', 'w') {|f| f.puts("XXX=000\n") }
+    result = system(%!bundle exec rails runner 'ENV["XXX"] == "000" ? exit : exit(1)'!)
+    if result
+      puts "[#{name}] Test case 'overwirte' succeeded"
+    else
+      $stderr.puts "[#{name}] Test case 'overwirte' failed"
       exit(1)
     end
   end


### PR DESCRIPTION
denv should load `.env` at first, then load custom env files.
