### PR TITLE
Retrieve secret values from backend storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ puts ENV['AWESOME_SERVICE_CREDENTIAL'] #=> "xxxxxx"
 ### Rails integration
 denv automatically sets initializer for your Rails application, so you only have to write gem dependency to your Gemfile.
 
+### Retrieve credentials
+You can retrieve credentials from backend storage in envfile.
+
+```sh
+DB_PASSWORD=<%= retrieve('db.password') %>
+```
+
+```ruby
+Denv::Storage.type = Denv::Storage::CredStash
+Denv.load
+```
+
 ### Command line tool
 ```
 denv --help

--- a/denv.gemspec
+++ b/denv.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'spring'
+  spec.add_development_dependency 'rcredstash'
 end

--- a/lib/denv.rb
+++ b/lib/denv.rb
@@ -79,7 +79,7 @@ module Denv
     WHITE_SPACES = /\s/
 
     def initialize(io, filename)
-      @io = io
+      @io = ERB.new(io.read).result
       @filename = filename
     end
 

--- a/lib/denv.rb
+++ b/lib/denv.rb
@@ -1,4 +1,5 @@
 require "denv/version"
+require "denv/storage"
 
 module Denv
   class Error < StandardError
@@ -79,7 +80,7 @@ module Denv
     WHITE_SPACES = /\s/
 
     def initialize(io, filename)
-      @io = ERB.new(io.read).result
+      @io = ERB.new(io.read).result(binding)
       @filename = filename
     end
 
@@ -103,6 +104,10 @@ module Denv
       end
 
       env
+    end
+
+    def retrieve(name)
+      Storage.instance.get(name)
     end
   end
 end

--- a/lib/denv/storage.rb
+++ b/lib/denv/storage.rb
@@ -1,0 +1,37 @@
+module Denv
+  module Storage
+    class << self
+      attr_writer :type
+
+      def instance
+        @instance ||= (@type || Base).new
+      end
+
+      def reset
+        @type = @instance = nil
+      end
+    end
+
+    class Base
+      def get(name)
+        raise "Set storage type: Denv::Storage.type = Denv::Storage::CredStash"
+      end
+    end
+
+    class CredStash < Base
+      def initialize
+        @cache = {}
+      end
+
+      def get(name)
+        str_name = name.to_s
+
+        if @cache.has_key?(str_name)
+          @cache[str_name]
+        else
+          @cache[str_name] = ::CredStash.get(name)
+        end
+      end
+    end
+  end
+end

--- a/spec/denv_spec.rb
+++ b/spec/denv_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe Denv do
           expect(parser.parse).to eq('x' => '"a text with double quotes"', 'y' => '"345"')
         end
       end
+
+      context 'with erb template' do
+        let(:content) { "x=<%= 1 + 2 %>\n" }
+
+        it 'render and parse it' do
+          expect(parser.parse).to eq('x' => '3')
+        end
+      end
     end
   end
 end

--- a/spec/denv_spec.rb
+++ b/spec/denv_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rcredstash'
 
 RSpec.describe Denv do
   describe Denv::Parser do
@@ -89,6 +90,23 @@ RSpec.describe Denv do
 
         it 'render and parse it' do
           expect(parser.parse).to eq('x' => '3')
+        end
+      end
+
+      context 'with credstash credential' do
+        let(:content) { "x=<%= retrieve('password') %>\n" }
+
+        before do
+          Denv::Storage.type = Denv::Storage::CredStash
+          expect(CredStash).to receive(:get).with('password').and_return('awesome_password')
+        end
+
+        after do
+          Denv::Storage.reset
+        end
+
+        it 'retrieve credentials' do
+          expect(parser.parse).to eq('x' => 'awesome_password')
         end
       end
     end


### PR DESCRIPTION
An envfile often contains secrets such as password, secret token, etc.
This pull request adds a feature to retrieve such secrets from a backend storage (DynamoDB) through CredStash.

`Denv::Storage` has a pluggable structure, so that we can add another storages(like Vault) as a backend.
