### PR TITLE
Let Rails.env evaluated correctly

### DIFF
--- a/lib/denv/rails.rb
+++ b/lib/denv/rails.rb
@@ -13,7 +13,7 @@ end
 
 module Denv
   class Railtie < ::Rails::Railtie
-    DEFAULT_ENV_FILES = %w[.env .env.#{Rails.env} .env.local]
+    DEFAULT_ENV_FILES = %W[.env .env.#{Rails.env} .env.local]
 
     config.before_configuration { load_env }
 


### PR DESCRIPTION
`%w` doesn't evaluated string interpolation... ;_;

before => [".env", ".env.\#{Rails.env}", ".env.local"]
after => [".env", ".env.test", ".env.local"]

Please review this. @taiki45 